### PR TITLE
fix: link global CSS in HTML to prevent FOUC

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <meta itemprop="alternateName" content="Secret Santa Generator"/>
     </div>
     <link rel="preconnect" href="https://ka-f.fontawesome.com" crossorigin>
+    <link rel="stylesheet" href="/assets/styles/all.css">
     <title>Gift Exchange Generator</title>
     <meta
             name="description"

--- a/pages/dashboard/index.html
+++ b/pages/dashboard/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Your participant dashboard for the gift exchange.">
+    <link rel="stylesheet" href="/assets/styles/all.css">
     <title>Participant Dashboard</title>
 </head>
 <body>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -1,4 +1,3 @@
-import '../../assets/styles/all.css';
 import btnStyles from '../../assets/styles/dashboard/components/buttons.module.css';
 import authGateStyles from '../../assets/styles/dashboard/components/auth-gate.module.css';
 import modalStyles from '../../assets/styles/dashboard/components/modal.module.css';

--- a/src/exchange/index.js
+++ b/src/exchange/index.js
@@ -1,4 +1,3 @@
-import '../../assets/styles/all.css';
 import {initDragDrop} from "./dragDrop.js";
 import * as house from "./components/House.js";
 import * as name from "./components/Name.js";


### PR DESCRIPTION
## Summary
- Move `all.css` out of JS imports and into `<link rel=\"stylesheet\">` tags in `index.html` and `pages/dashboard/index.html` so global base/layout/token styles land before first paint instead of after the module graph evaluates.
- Component-level `*.module.css` files continue to be imported from JS (Vite extracts them into per-page bundles in prod).

## Test plan
- [ ] `npm run build && npm run preview` — verify `<link>` for `all.css` and the auto-extracted module bundle both appear in `<head>` on `/` and `/dashboard`
- [ ] Visually confirm no FOUC on hard refresh of the home page in prod build
- [ ] `npm test` passes
- [ ] `npm run e2e` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)