### PR TITLE
Admin logs: date-range indicator, configurable log level, endpoint-format fix

### DIFF
--- a/assets/styles/admin/base.css
+++ b/assets/styles/admin/base.css
@@ -172,14 +172,20 @@ body:has(.admin-page) {
 
 .admin-filters {
   display: flex;
+  flex-direction: column;
   gap: 10px;
-  flex-wrap: wrap;
-  align-items: flex-end;
   margin-bottom: 20px;
   padding: 16px 20px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--frost-border);
   border-radius: var(--radius-md);
+}
+
+.admin-filter-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: flex-end;
 }
 
 .admin-filter-group {
@@ -232,13 +238,35 @@ body:has(.admin-page) {
 
 .admin-filter-action {
   justify-content: flex-end;
+  margin-left: auto;
 }
 
-.admin-header .admin-log-level {
+.admin-filter-grow {
+  flex: 1 1 200px;
+}
+
+.admin-filter-grow input {
+  width: 100%;
+}
+
+.admin-toolbar {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.admin-toolbar .admin-filters {
   margin-bottom: 0;
-  margin-left: auto;
-  padding: 8px 14px;
-  flex-wrap: nowrap;
+}
+
+#filters-container {
+  flex: 1 1 480px;
+}
+
+#log-level-container {
+  flex: 0 0 auto;
 }
 
 /* ── Table ──────────────────────────────────────────────────── */

--- a/assets/styles/admin/base.css
+++ b/assets/styles/admin/base.css
@@ -234,6 +234,13 @@ body:has(.admin-page) {
   justify-content: flex-end;
 }
 
+.admin-header .admin-log-level {
+  margin-bottom: 0;
+  margin-left: auto;
+  padding: 8px 14px;
+  flex-wrap: nowrap;
+}
+
 /* ── Table ──────────────────────────────────────────────────── */
 
 .admin-table-summary {

--- a/dev/dev-db.mjs
+++ b/dev/dev-db.mjs
@@ -1,11 +1,21 @@
 import {MongoMemoryServer} from "mongodb-memory-server";
 import {MongoClient} from "mongodb";
 import fs from "node:fs";
+import path from "node:path";
+import {execSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
 import {seed} from "./seed.mjs";
 import {startRepl} from "./repl.mjs";
 
 const DB_NAME = "gift-exchange";
-const ENV_FILE = ".env.local";
+
+export function resolveEnvFilePath() {
+    const gitCommonDir = execSync("git rev-parse --git-common-dir", {encoding: "utf-8"}).trim();
+    const repoRoot = path.dirname(path.resolve(gitCommonDir));
+    return path.join(repoRoot, ".env.local");
+}
+
+const ENV_FILE = resolveEnvFilePath();
 
 function readEnvFile() {
     try {
@@ -41,4 +51,6 @@ async function startMongo() {
     startRepl(db, client, () => mongod.stop());
 }
 
-startMongo().catch(console.error);
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    startMongo().catch(console.error);
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "checkJs": false
+    },
+    "exclude": ["node_modules", "dist", ".netlify"]
+}

--- a/netlify/functions/api-admin-code-post.mjs
+++ b/netlify/functions/api-admin-code-post.mjs
@@ -2,7 +2,6 @@ import {apiHandler} from "../shared/middleware.mjs";
 import {ok} from "../shared/responses.mjs";
 import {generateAndStoreCode} from "../shared/authCodes.mjs";
 import {sendNotificationEmail} from "../shared/giverNotification.mjs";
-import {logger} from "../shared/logger.mjs";
 
 export const handler = apiHandler("POST", async (event) => {
     const email = process.env.ADMIN_EMAIL;
@@ -16,6 +15,5 @@ export const handler = apiHandler("POST", async (event) => {
         {code}
     );
 
-    logger.info("Admin code requested", {endpoint: event.path, ip: event.ip});
     return ok({sent: true});
 }, {maxRequests: 3, windowMs: 60000});

--- a/netlify/functions/api-admin-logs-get.mjs
+++ b/netlify/functions/api-admin-logs-get.mjs
@@ -34,5 +34,8 @@ export const handler = apiHandler("GET", async (event) => {
     ]);
     const distinctEndpoints = rawEndpoints.filter(Boolean).sort();
 
-    return ok({logs, total, page: pageNum, pages: Math.ceil(total / pageSize), distinctEndpoints});
+    return ok({
+        logs, total, page: pageNum, pages: Math.ceil(total / pageSize), distinctEndpoints,
+        range: {from: fromDate.toISOString(), to: toDate.toISOString()},
+    });
 }, {auth: true});

--- a/netlify/functions/api-admin-settings-get.mjs
+++ b/netlify/functions/api-admin-settings-get.mjs
@@ -1,0 +1,12 @@
+import {apiHandler} from "../shared/middleware.mjs";
+import {ok, forbidden} from "../shared/responses.mjs";
+import {getLogLevel} from "../shared/settings.mjs";
+
+export const handler = apiHandler("GET", async (event) => {
+    if (event.user.email !== process.env.ADMIN_EMAIL) {
+        return forbidden("Forbidden");
+    }
+
+    const logLevel = await getLogLevel();
+    return ok({logLevel});
+}, {auth: true});

--- a/netlify/functions/api-admin-settings-put.mjs
+++ b/netlify/functions/api-admin-settings-put.mjs
@@ -1,0 +1,20 @@
+import {z} from "zod";
+import {apiHandler, validateBody} from "../shared/middleware.mjs";
+import {ok, badRequest, forbidden} from "../shared/responses.mjs";
+import {setLogLevel} from "../shared/settings.mjs";
+
+const settingsPutRequestSchema = z.object({
+    logLevel: z.enum(["debug", "info", "warn", "error"]),
+});
+
+export const handler = apiHandler("PUT", async (event) => {
+    if (event.user.email !== process.env.ADMIN_EMAIL) {
+        return forbidden("Forbidden");
+    }
+
+    const {data, error} = validateBody(settingsPutRequestSchema, event);
+    if (error) return badRequest(error);
+
+    await setLogLevel(data.logLevel);
+    return ok({logLevel: data.logLevel});
+}, {auth: true});

--- a/netlify/functions/api-admin-verify-post.mjs
+++ b/netlify/functions/api-admin-verify-post.mjs
@@ -1,5 +1,5 @@
 import {z} from "zod";
-import {apiHandler, validateBody} from "../shared/middleware.mjs";
+import {apiHandler, validateBody, requestEndpoint} from "../shared/middleware.mjs";
 import {badRequest, unauthorized, okWithHeaders} from "../shared/responses.mjs";
 import {getUsersCollection} from "../shared/db.mjs";
 import {verifyCode} from "../shared/authCodes.mjs";
@@ -17,7 +17,7 @@ export const handler = apiHandler("POST", async (event) => {
     const email = process.env.ADMIN_EMAIL;
     const result = await verifyCode(email, data.code);
     if (!result.valid) {
-        logger.warn("Admin login failed - invalid code", {endpoint: event.path, ip: event.ip});
+        logger.warn("Admin login failed - invalid code", {endpoint: requestEndpoint(event), ip: event.ip});
         return unauthorized(result.error);
     }
 
@@ -28,7 +28,7 @@ export const handler = apiHandler("POST", async (event) => {
         {upsert: true, returnDocument: "after"}
     );
 
-    logger.info("Admin login success", {endpoint: event.path, ip: event.ip});
+    logger.info("Admin login success", {endpoint: requestEndpoint(event), ip: event.ip});
     const jwt = await signSession(user._id.toString());
     return okWithHeaders({success: true}, {"Set-Cookie": buildSessionCookie(jwt)});
 }, {maxRequests: 5, windowMs: 60000});

--- a/netlify/functions/api-auth-code-post.mjs
+++ b/netlify/functions/api-auth-code-post.mjs
@@ -1,5 +1,5 @@
 import {z} from "zod";
-import {apiHandler, validateBody} from "../shared/middleware.mjs";
+import {apiHandler, validateBody, requestEndpoint} from "../shared/middleware.mjs";
 import {ok, badRequest} from "../shared/responses.mjs";
 import {getUsersCollection} from "../shared/db.mjs";
 import {generateAndStoreCode} from "../shared/authCodes.mjs";
@@ -21,9 +21,9 @@ export const handler = apiHandler("POST", async (event) => {
     if (user) {
         const code = await generateAndStoreCode(email);
         await sendNotificationEmail("verification-code", email, "Your Gift Exchange Verification Code", {code});
-        logger.info("Auth code sent", {endpoint: event.path, ip: event.ip, email});
+        logger.info("Auth code sent", {endpoint: requestEndpoint(event), ip: event.ip, email});
     } else {
-        logger.info("Auth code requested - email not found", {endpoint: event.path, ip: event.ip, email});
+        logger.info("Auth code requested - email not found", {endpoint: requestEndpoint(event), ip: event.ip, email});
     }
 
     return ok({sent: true});

--- a/netlify/functions/api-auth-verify-post.mjs
+++ b/netlify/functions/api-auth-verify-post.mjs
@@ -1,5 +1,5 @@
 import {z} from "zod";
-import {apiHandler, validateBody} from "../shared/middleware.mjs";
+import {apiHandler, validateBody, requestEndpoint} from "../shared/middleware.mjs";
 import {badRequest, unauthorized, okWithHeaders} from "../shared/responses.mjs";
 import {getUsersCollection} from "../shared/db.mjs";
 import {verifyCode} from "../shared/authCodes.mjs";
@@ -19,7 +19,7 @@ export const handler = apiHandler("POST", async (event) => {
     const email = data.email.trim();
     const result = await verifyCode(email, data.code);
     if (!result.valid) {
-        logger.warn("Login failed - invalid code", {endpoint: event.path, ip: event.ip, email});
+        logger.warn("Login failed - invalid code", {endpoint: requestEndpoint(event), ip: event.ip, email});
         return unauthorized(result.error);
     }
 
@@ -36,12 +36,12 @@ export const handler = apiHandler("POST", async (event) => {
             },
             {upsert: true, returnDocument: "after"}
         );
-        if (isNew) logger.info("New user created", {endpoint: event.path, ip: event.ip, email});
-        else logger.info("Login success", {endpoint: event.path, ip: event.ip, email});
+        if (isNew) logger.info("New user created", {endpoint: requestEndpoint(event), ip: event.ip, email});
+        else logger.info("Login success", {endpoint: requestEndpoint(event), ip: event.ip, email});
     } else {
         user = await usersCol.findOne({email});
         if (!user) return unauthorized("Authentication failed");
-        logger.info("Login success", {endpoint: event.path, ip: event.ip, email});
+        logger.info("Login success", {endpoint: requestEndpoint(event), ip: event.ip, email});
     }
 
     const jwt = await signSession(user._id.toString());

--- a/netlify/functions/api-exchange-post.mjs
+++ b/netlify/functions/api-exchange-post.mjs
@@ -1,5 +1,5 @@
 import {getExchangesCollection, getUsersCollection} from "../shared/db.mjs";
-import {apiHandler, validateBody} from "../shared/middleware.mjs";
+import {apiHandler, validateBody, requestEndpoint} from "../shared/middleware.mjs";
 import {badRequest, ok} from "../shared/responses.mjs";
 import {sendBatchEmails} from "../shared/giverNotification.mjs";
 import {logger} from "../shared/logger.mjs";
@@ -130,9 +130,9 @@ export const handler = apiHandler("POST", async (event) => {
 
     const {emailsFailed} = await sendBatchEmails(data.participants, data.assignments, userByEmail, data.exchangeId);
 
-    logger.info("Exchange created", {endpoint: event.path, ip: event.ip, exchangeId: data.exchangeId, participantCount: data.participants.length});
+    logger.info("Exchange created", {endpoint: requestEndpoint(event), ip: event.ip, exchangeId: data.exchangeId, participantCount: data.participants.length});
     if (emailsFailed.length > 0) {
-        logger.error("Exchange email send failures", {endpoint: event.path, ip: event.ip, exchangeId: data.exchangeId, emailsFailed});
+        logger.error("Exchange email send failures", {endpoint: requestEndpoint(event), ip: event.ip, exchangeId: data.exchangeId, emailsFailed});
     }
 
     return ok({...buildResponse(data.exchangeId, data.participants), emailsFailed});

--- a/netlify/functions/api-giver-retry-post.mjs
+++ b/netlify/functions/api-giver-retry-post.mjs
@@ -1,5 +1,5 @@
 import {z} from "zod";
-import {apiHandler, validateBody} from "../shared/middleware.mjs";
+import {apiHandler, validateBody, requestEndpoint} from "../shared/middleware.mjs";
 import {ok, badRequest, forbidden, notFound} from "../shared/responses.mjs";
 import {sendNotificationEmail, sendBatchEmails} from "../shared/giverNotification.mjs";
 import {getUsersCollection, getExchangesCollection} from "../shared/db.mjs";
@@ -97,10 +97,10 @@ export const handler = apiHandler("POST", async (event) => {
     const userByEmail = Object.fromEntries(participantUsers.map(u => [u.email, u]));
     const {emailsFailed} = await sendBatchEmails(participants, assignments, userByEmail, data.exchangeId);
 
-    logger.info("Giver retry initiated", {endpoint: event.path, ip: event.ip, exchangeId: data.exchangeId, sent: assignments.length - emailsFailed.length});
+    logger.info("Giver retry initiated", {endpoint: requestEndpoint(event), ip: event.ip, exchangeId: data.exchangeId, sent: assignments.length - emailsFailed.length});
 
     if (emailsFailed.length > 0) {
-        logger.error("Giver retry email failures", {endpoint: event.path, ip: event.ip, exchangeId: data.exchangeId, emailsFailed});
+        logger.error("Giver retry email failures", {endpoint: requestEndpoint(event), ip: event.ip, exchangeId: data.exchangeId, emailsFailed});
         await alertEmailFailures(emailsFailed, assignments);
     }
 

--- a/netlify/functions/api-user-contact-post.mjs
+++ b/netlify/functions/api-user-contact-post.mjs
@@ -1,5 +1,5 @@
 import {z} from "zod";
-import {apiHandler, validateBody} from "../shared/middleware.mjs";
+import {apiHandler, validateBody, requestEndpoint} from "../shared/middleware.mjs";
 import {ok, badRequest} from "../shared/responses.mjs";
 import {forEachGiverOf, sendNotificationEmail} from "../shared/giverNotification.mjs";
 import {logger} from "../shared/logger.mjs";
@@ -30,6 +30,6 @@ export const handler = apiHandler("POST", async (event) => {
         );
     });
 
-    logger.info("Contact info shared", {endpoint: event.path, ip: event.ip, userId: user._id.toString()});
+    logger.info("Contact info shared", {endpoint: requestEndpoint(event), ip: event.ip, userId: user._id.toString()});
     return ok({success: true});
 }, {auth: true, maxRequests: 5, windowMs: 60000});

--- a/netlify/functions/api-user-wishlist-put.mjs
+++ b/netlify/functions/api-user-wishlist-put.mjs
@@ -1,4 +1,4 @@
-import {apiHandler, validateBody} from "../shared/middleware.mjs";
+import {apiHandler, validateBody, requestEndpoint} from "../shared/middleware.mjs";
 import {ok, badRequest} from "../shared/responses.mjs";
 import {getUsersCollection} from "../shared/db.mjs";
 import {forEachGiverOf, sendNotificationEmail} from "../shared/giverNotification.mjs";
@@ -33,7 +33,7 @@ export const handler = apiHandler("PUT", async (event) => {
             );
         });
         notifiedGivers = true;
-        logger.info("Wishlist first added", {endpoint: event.path, ip: event.ip, userId: user._id.toString()});
+        logger.info("Wishlist first added", {endpoint: requestEndpoint(event), ip: event.ip, userId: user._id.toString()});
     }
 
     return ok({success: true, notifiedGivers});

--- a/netlify/shared/db.mjs
+++ b/netlify/shared/db.mjs
@@ -42,3 +42,8 @@ export async function getLogsCollection() {
     const db = await getDb();
     return db.collection("logs");
 }
+
+export async function getSettingsCollection() {
+    const db = await getDb();
+    return db.collection("settings");
+}

--- a/netlify/shared/logger.mjs
+++ b/netlify/shared/logger.mjs
@@ -1,6 +1,12 @@
 import {getLogsCollection} from "./db.mjs";
+import {getLogLevel} from "./settings.mjs";
+
+const LEVEL_ORDER = {debug: 0, info: 1, warn: 2, error: 3};
 
 async function log(level, message, {endpoint, ip, ...metadata} = {}) {
+    const threshold = await getLogLevel();
+    if (LEVEL_ORDER[level] < LEVEL_ORDER[threshold]) return;
+
     const consoleFn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
     const hasExtra = Object.keys(metadata).length > 0 || endpoint != null || ip != null;
     consoleFn(message, ...(hasExtra ? [{endpoint, ip, ...metadata}] : []));

--- a/netlify/shared/middleware.mjs
+++ b/netlify/shared/middleware.mjs
@@ -37,13 +37,17 @@ export function validateBody(schema, event) {
 
 const ALLOWED_ORIGINS = ["gift-exchange-generator.com", "giftexchangegenerator.netlify.app"];
 
+export function requestEndpoint(event) {
+    return `${event.httpMethod} ${event.path}`;
+}
+
 export function validateOrigin(event) {
     const origin = event.headers?.origin;
     if (!origin) return null;
     if (ALLOWED_ORIGINS.some((allowed) => origin.includes(allowed))) return null;
     if (origin === process.env.URL) return null;
 
-    logger.warn("Origin rejected", {endpoint: event.path, ip: extractClientIp(event), origin});
+    logger.warn("Origin rejected", {endpoint: requestEndpoint(event), ip: extractClientIp(event), origin});
     return forbidden("Forbidden");
 }
 
@@ -84,7 +88,7 @@ async function applyRateLimit(event, rateLimitConfig) {
 
 async function reportError(event, error) {
     logger.error("Unhandled error in API handler", {
-        endpoint: `${event.httpMethod} ${event.path}`,
+        endpoint: requestEndpoint(event),
         stack: error.stack || error.message,
     });
     try {
@@ -93,7 +97,7 @@ async function reportError(event, error) {
             "alex@gift-exchange-generator.com",
             `Server Error: ${error.message}`,
             {
-                endpoint: `${event.httpMethod} ${event.path}`,
+                endpoint: requestEndpoint(event),
                 timestamp: new Date().toISOString(),
                 stackTrace: error.stack || error.message,
             }
@@ -103,7 +107,7 @@ async function reportError(event, error) {
 
 export function apiHandler(method, fn, {auth = false, ...rateLimitConfig} = {}) {
     return async (event) => {
-        const endpoint = `${event.httpMethod} ${event.path}`;
+        const endpoint = requestEndpoint(event);
         const ip = extractClientIp(event);
         event.ip = ip;
         logger.info(`[API] ${endpoint}`, {endpoint, ip});

--- a/netlify/shared/schemas/settings.mjs
+++ b/netlify/shared/schemas/settings.mjs
@@ -1,0 +1,10 @@
+import {z} from "zod";
+
+export const settingsSchema = z.object({
+    _id: z.literal("global"),
+    logLevel: z.enum(["debug", "info", "warn", "error"]),
+});
+
+export const collection = 'settings';
+
+export const indexes = [];

--- a/netlify/shared/settings.mjs
+++ b/netlify/shared/settings.mjs
@@ -1,0 +1,34 @@
+import {getSettingsCollection} from "./db.mjs";
+
+const CACHE_TTL_MS = 15000;
+const DEFAULT_LEVEL = "warn";
+
+let cachedLevel = null;
+let cachedAt = 0;
+
+export function _resetLogLevelCache() {
+    cachedLevel = null;
+    cachedAt = 0;
+}
+
+export async function getLogLevel() {
+    if (cachedLevel && Date.now() - cachedAt < CACHE_TTL_MS) {
+        return cachedLevel;
+    }
+    try {
+        const col = await getSettingsCollection();
+        const doc = await col.findOne({_id: "global"});
+        cachedLevel = doc?.logLevel ?? DEFAULT_LEVEL;
+        cachedAt = Date.now();
+        return cachedLevel;
+    } catch {
+        return "debug";
+    }
+}
+
+export async function setLogLevel(level) {
+    const col = await getSettingsCollection();
+    await col.updateOne({_id: "global"}, {$set: {logLevel: level}}, {upsert: true});
+    cachedLevel = level;
+    cachedAt = Date.now();
+}

--- a/spec/admin/logLevelControl.spec.js
+++ b/spec/admin/logLevelControl.spec.js
@@ -1,0 +1,60 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderLogLevelControl} from '../../src/admin/logLevelControl.js';
+import * as snackbar from '../../src/Snackbar.js';
+
+describe('logLevelControl', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="log-level-container"></div>';
+        snackbar.init();
+    });
+
+    it('renders a select with all four log levels', () => {
+        global.fetch = vi.fn().mockResolvedValue({ok: true, json: () => Promise.resolve({logLevel: 'warn'})});
+        renderLogLevelControl(document.getElementById('log-level-container'));
+        const select = document.getElementById('log-level-select');
+        const values = Array.from(select.options).map(o => o.value);
+        expect(values).toEqual(['debug', 'info', 'warn', 'error']);
+    });
+
+    it('loads and displays the current log level on render', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ok: true, json: () => Promise.resolve({logLevel: 'error'})});
+        renderLogLevelControl(document.getElementById('log-level-container'));
+        await vi.waitFor(() => {
+            expect(document.getElementById('log-level-select').value).toBe('error');
+        });
+    });
+
+    it('saves the selected level and shows a success snackbar', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce({ok: true, json: () => Promise.resolve({logLevel: 'warn'})})
+            .mockResolvedValueOnce({ok: true, json: () => Promise.resolve({logLevel: 'error'})});
+        renderLogLevelControl(document.getElementById('log-level-container'));
+        await vi.waitFor(() => expect(document.getElementById('log-level-select').value).toBe('warn'));
+
+        document.getElementById('log-level-select').value = 'error';
+        document.getElementById('log-level-save').click();
+
+        await vi.waitFor(() => {
+            expect(document.getElementById('snackbar').textContent).toContain('Log level updated');
+        });
+        expect(global.fetch).toHaveBeenLastCalledWith('/.netlify/functions/api-admin-settings-put', {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({logLevel: 'error'}),
+        });
+    });
+
+    it('shows an error snackbar when saving fails', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce({ok: true, json: () => Promise.resolve({logLevel: 'warn'})})
+            .mockResolvedValueOnce({ok: false});
+        renderLogLevelControl(document.getElementById('log-level-container'));
+        await vi.waitFor(() => expect(document.getElementById('log-level-select').value).toBe('warn'));
+
+        document.getElementById('log-level-save').click();
+
+        await vi.waitFor(() => {
+            expect(document.getElementById('snackbar').textContent).toContain('Failed to update log level');
+        });
+    });
+});

--- a/spec/admin/logTable.spec.js
+++ b/spec/admin/logTable.spec.js
@@ -1,0 +1,28 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderTable} from '../../src/admin/logTable.js';
+
+const sampleLog = {timestamp: new Date().toISOString(), level: 'info', message: 'Test', endpoint: null, ip: null};
+
+describe('logTable', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="logs-container"></div>';
+    });
+
+    it('renders the active date range in the summary line', () => {
+        renderTable({
+            logs: [sampleLog],
+            total: 1,
+            page: 1,
+            pages: 1,
+            range: {from: '2026-07-15T14:00:00.000Z', to: '2026-07-16T14:00:00.000Z'},
+        }, vi.fn());
+        const summary = document.querySelector('.admin-table-summary').textContent;
+        expect(summary).toContain(new Date('2026-07-15T14:00:00.000Z').toLocaleString());
+        expect(summary).toContain(new Date('2026-07-16T14:00:00.000Z').toLocaleString());
+    });
+
+    it('renders without range text when range is not provided', () => {
+        renderTable({logs: [sampleLog], total: 1, page: 1, pages: 1}, vi.fn());
+        expect(document.querySelector('.admin-table-summary').textContent).toBe('Showing 1 of 1 logs');
+    });
+});

--- a/spec/dev/dev-db.spec.js
+++ b/spec/dev/dev-db.spec.js
@@ -1,0 +1,24 @@
+import {describe, it, expect, vi} from 'vitest';
+
+vi.mock('node:child_process', () => ({
+    execSync: vi.fn(),
+}));
+
+describe('resolveEnvFilePath', () => {
+    it('resolves .env.local to the repo root when git-common-dir is absolute (worktree)', async () => {
+        const {execSync} = await import('node:child_process');
+        execSync.mockReturnValue('/Users/alex/project/.git\n');
+        const {resolveEnvFilePath} = await import('../../dev/dev-db.mjs');
+        expect(resolveEnvFilePath()).toBe('/Users/alex/project/.env.local');
+    });
+
+    it('resolves .env.local to the repo root when git-common-dir is relative to cwd (main checkout)', async () => {
+        vi.resetModules();
+        const {execSync} = await import('node:child_process');
+        execSync.mockReturnValue('.git\n');
+        const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/Users/alex/project');
+        const {resolveEnvFilePath} = await import('../../dev/dev-db.mjs');
+        expect(resolveEnvFilePath()).toBe('/Users/alex/project/.env.local');
+        cwdSpy.mockRestore();
+    });
+});

--- a/spec/netlify-functions/api-admin-code-post.spec.js
+++ b/spec/netlify-functions/api-admin-code-post.spec.js
@@ -67,11 +67,6 @@ describe('api-admin-code-post', () => {
         expect(response.statusCode).toBe(429);
     });
 
-    it('logs info when admin code is requested', async () => {
-        await handler(buildEvent('POST'));
-        expect(vi.mocked(logger.info)).toHaveBeenCalledWith('Admin code requested', expect.any(Object));
-    });
-
     it('returns 500 and logs error when ADMIN_EMAIL is not configured', async () => {
         delete process.env.ADMIN_EMAIL;
         const response = await handler(buildEvent('POST'));

--- a/spec/netlify-functions/api-admin-logs-get.spec.js
+++ b/spec/netlify-functions/api-admin-logs-get.spec.js
@@ -69,6 +69,17 @@ describe("api-admin-logs-get", () => {
         expect(body.pages).toBe(0);
     });
 
+    it("returns the resolved query range", async () => {
+        await seedUsers(db, adminUser);
+        const event = buildEvent("GET", {
+            headers: {cookie: await authCookie(adminUser._id)},
+            queryStringParameters: {from: "2026-07-01T00:00:00.000Z", to: "2026-07-02T00:00:00.000Z"},
+        });
+        const response = await handler(event);
+        const body = JSON.parse(response.body);
+        expect(body.range).toEqual({from: "2026-07-01T00:00:00.000Z", to: "2026-07-02T00:00:00.000Z"});
+    });
+
     it("returns logs within default 24h window", async () => {
         await seedUsers(db, adminUser);
         const col = db.collection("logs");

--- a/spec/netlify-functions/api-admin-settings-get.spec.js
+++ b/spec/netlify-functions/api-admin-settings-get.spec.js
@@ -1,0 +1,74 @@
+import {describe, it, expect, beforeAll, afterAll, afterEach, vi} from "vitest";
+import {setupMongo, teardownMongo, cleanCollections} from '../shared/mongoSetup.js';
+import {makeUser, seedUsers} from "../shared/testData.js";
+import {authCookie, buildEvent} from "../shared/specHelper.js";
+
+vi.mock("../../netlify/shared/logger.mjs", () => ({
+    logger: {info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn()},
+}));
+
+describe("api-admin-settings-get", () => {
+    let db, handler, mongo, setLogLevel, _resetLogLevelCache;
+
+    const adminUser = makeUser({email: "admin@example.com"});
+    const regularUser = makeUser({email: "user@example.com"});
+
+    beforeAll(async () => {
+        mongo = await setupMongo();
+        ({db} = mongo);
+        process.env.JWT_SECRET = "test-secret";
+        process.env.ADMIN_EMAIL = "admin@example.com";
+        const mod = await import("../../netlify/functions/api-admin-settings-get.mjs");
+        handler = mod.handler;
+        const settingsMod = await import("../../netlify/shared/settings.mjs");
+        setLogLevel = settingsMod.setLogLevel;
+        _resetLogLevelCache = settingsMod._resetLogLevelCache;
+    });
+
+    afterEach(async () => {
+        _resetLogLevelCache();
+        await cleanCollections(db, "users", "settings");
+    });
+
+    afterAll(async () => {
+        delete process.env.JWT_SECRET;
+        delete process.env.ADMIN_EMAIL;
+        await teardownMongo(mongo);
+    });
+
+    it("returns 405 for non-GET requests", async () => {
+        await seedUsers(db, adminUser);
+        const event = buildEvent("POST", {headers: {cookie: await authCookie(adminUser._id)}});
+        const response = await handler(event);
+        expect(response.statusCode).toBe(405);
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+        const event = buildEvent("GET");
+        const response = await handler(event);
+        expect(response.statusCode).toBe(401);
+    });
+
+    it("returns 403 when authenticated as non-admin", async () => {
+        await seedUsers(db, regularUser);
+        const event = buildEvent("GET", {headers: {cookie: await authCookie(regularUser._id)}});
+        const response = await handler(event);
+        expect(response.statusCode).toBe(403);
+    });
+
+    it("returns the default log level when none is set", async () => {
+        await seedUsers(db, adminUser);
+        const event = buildEvent("GET", {headers: {cookie: await authCookie(adminUser._id)}});
+        const response = await handler(event);
+        expect(response.statusCode).toBe(200);
+        expect(JSON.parse(response.body).logLevel).toBe("warn");
+    });
+
+    it("returns the configured log level", async () => {
+        await seedUsers(db, adminUser);
+        await setLogLevel("error");
+        const event = buildEvent("GET", {headers: {cookie: await authCookie(adminUser._id)}});
+        const response = await handler(event);
+        expect(JSON.parse(response.body).logLevel).toBe("error");
+    });
+});

--- a/spec/netlify-functions/api-admin-settings-put.spec.js
+++ b/spec/netlify-functions/api-admin-settings-put.spec.js
@@ -1,0 +1,83 @@
+import {describe, it, expect, beforeAll, afterAll, afterEach, vi} from "vitest";
+import {setupMongo, teardownMongo, cleanCollections} from '../shared/mongoSetup.js';
+import {makeUser, seedUsers} from "../shared/testData.js";
+import {authCookie, buildEvent} from "../shared/specHelper.js";
+
+vi.mock("../../netlify/shared/logger.mjs", () => ({
+    logger: {info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn()},
+}));
+
+describe("api-admin-settings-put", () => {
+    let db, handler, mongo, _resetLogLevelCache;
+
+    const adminUser = makeUser({email: "admin@example.com"});
+    const regularUser = makeUser({email: "user@example.com"});
+
+    beforeAll(async () => {
+        mongo = await setupMongo();
+        ({db} = mongo);
+        process.env.JWT_SECRET = "test-secret";
+        process.env.ADMIN_EMAIL = "admin@example.com";
+        const mod = await import("../../netlify/functions/api-admin-settings-put.mjs");
+        handler = mod.handler;
+        const settingsMod = await import("../../netlify/shared/settings.mjs");
+        _resetLogLevelCache = settingsMod._resetLogLevelCache;
+    });
+
+    afterEach(async () => {
+        _resetLogLevelCache();
+        await cleanCollections(db, "users", "settings");
+    });
+
+    afterAll(async () => {
+        delete process.env.JWT_SECRET;
+        delete process.env.ADMIN_EMAIL;
+        await teardownMongo(mongo);
+    });
+
+    it("returns 405 for non-PUT requests", async () => {
+        await seedUsers(db, adminUser);
+        const event = buildEvent("GET", {headers: {cookie: await authCookie(adminUser._id)}});
+        const response = await handler(event);
+        expect(response.statusCode).toBe(405);
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+        const event = buildEvent("PUT", {body: {logLevel: "error"}});
+        const response = await handler(event);
+        expect(response.statusCode).toBe(401);
+    });
+
+    it("returns 403 when authenticated as non-admin", async () => {
+        await seedUsers(db, regularUser);
+        const event = buildEvent("PUT", {
+            headers: {cookie: await authCookie(regularUser._id)},
+            body: {logLevel: "error"},
+        });
+        const response = await handler(event);
+        expect(response.statusCode).toBe(403);
+    });
+
+    it("returns 400 for an invalid logLevel", async () => {
+        await seedUsers(db, adminUser);
+        const event = buildEvent("PUT", {
+            headers: {cookie: await authCookie(adminUser._id)},
+            body: {logLevel: "verbose"},
+        });
+        const response = await handler(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it("updates the log level and returns it", async () => {
+        await seedUsers(db, adminUser);
+        const event = buildEvent("PUT", {
+            headers: {cookie: await authCookie(adminUser._id)},
+            body: {logLevel: "error"},
+        });
+        const response = await handler(event);
+        expect(response.statusCode).toBe(200);
+        expect(JSON.parse(response.body).logLevel).toBe("error");
+        const doc = await db.collection("settings").findOne({_id: "global"});
+        expect(doc.logLevel).toBe("error");
+    });
+});

--- a/spec/netlify-functions/db.spec.js
+++ b/spec/netlify-functions/db.spec.js
@@ -3,7 +3,7 @@ import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
 describe('db utility', () => {
     let consoleLogSpy;
     let consoleErrorSpy;
-    let getDb, getUsersCollection, getExchangesCollection;
+    let getDb, getUsersCollection, getExchangesCollection, getSettingsCollection;
 
     beforeAll(async () => {
         consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -13,6 +13,7 @@ describe('db utility', () => {
         getDb = module.getDb;
         getUsersCollection = module.getUsersCollection;
         getExchangesCollection = module.getExchangesCollection;
+        getSettingsCollection = module.getSettingsCollection;
     });
 
     afterAll(async () => {
@@ -49,6 +50,14 @@ describe('db utility', () => {
             const collection = await getExchangesCollection();
             expect(collection).toBeDefined();
             expect(collection.collectionName).toBe('exchanges');
+        });
+    });
+
+    describe('getSettingsCollection', () => {
+        it('returns the settings collection', async () => {
+            const collection = await getSettingsCollection();
+            expect(collection).toBeDefined();
+            expect(collection.collectionName).toBe('settings');
         });
     });
 

--- a/spec/netlify-functions/logger.spec.js
+++ b/spec/netlify-functions/logger.spec.js
@@ -84,19 +84,19 @@ describe("logger", () => {
 
     it("skips console output and db insert when level is below threshold", async () => {
         await setLogLevel("warn");
-        const spy = vi.spyOn(console, "log").mockImplementation(() => {});
         await logger.info("Should be suppressed");
-        expect(spy).not.toHaveBeenCalled();
+        expect(mongo.consoleLogSpy).not.toHaveBeenCalledWith("Should be suppressed");
         const doc = await db.collection("logs").findOne({message: "Should be suppressed"});
         expect(doc).toBeNull();
-        spy.mockRestore();
     });
 
     it("logs when level is at or above threshold", async () => {
         await setLogLevel("warn");
+        const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
         await logger.warn("Should be logged");
         const doc = await db.collection("logs").findOne({message: "Should be logged"});
         expect(doc).not.toBeNull();
+        spy.mockRestore();
     });
 
     it("fails open (logs everything) when settings lookup fails", async () => {

--- a/spec/netlify-functions/logger.spec.js
+++ b/spec/netlify-functions/logger.spec.js
@@ -1,18 +1,24 @@
-import {describe, it, expect, beforeAll, afterAll, afterEach, vi} from "vitest";
+import {describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi} from "vitest";
 import {setupMongo, teardownMongo, cleanCollections} from '../shared/mongoSetup.js';
 
 describe("logger", () => {
-    let db, mongo, logger;
+    let db, mongo, logger, setLogLevel;
 
     beforeAll(async () => {
         mongo = await setupMongo();
         ({db} = mongo);
         const mod = await import("../../netlify/shared/logger.mjs");
         logger = mod.logger;
+        const settingsMod = await import("../../netlify/shared/settings.mjs");
+        setLogLevel = settingsMod.setLogLevel;
+    });
+
+    beforeEach(async () => {
+        await setLogLevel("debug");
     });
 
     afterEach(async () => {
-        await cleanCollections(db, "logs");
+        await cleanCollections(db, "logs", "settings");
     });
 
     afterAll(async () => {
@@ -74,5 +80,31 @@ describe("logger", () => {
         await expect(logger.warn("Should not throw")).resolves.not.toThrow();
         spy.mockRestore();
         warnSpy.mockRestore();
+    });
+
+    it("skips console output and db insert when level is below threshold", async () => {
+        await setLogLevel("warn");
+        const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+        await logger.info("Should be suppressed");
+        expect(spy).not.toHaveBeenCalled();
+        const doc = await db.collection("logs").findOne({message: "Should be suppressed"});
+        expect(doc).toBeNull();
+        spy.mockRestore();
+    });
+
+    it("logs when level is at or above threshold", async () => {
+        await setLogLevel("warn");
+        await logger.warn("Should be logged");
+        const doc = await db.collection("logs").findOne({message: "Should be logged"});
+        expect(doc).not.toBeNull();
+    });
+
+    it("fails open (logs everything) when settings lookup fails", async () => {
+        const dbMod = await import("../../netlify/shared/db.mjs");
+        const spy = vi.spyOn(dbMod, "getSettingsCollection").mockRejectedValueOnce(new Error("DB down"));
+        await logger.info("Should still log");
+        const doc = await db.collection("logs").findOne({message: "Should still log"});
+        expect(doc).not.toBeNull();
+        spy.mockRestore();
     });
 });

--- a/spec/netlify-functions/middleware.spec.js
+++ b/spec/netlify-functions/middleware.spec.js
@@ -12,7 +12,7 @@ vi.mock('../../netlify/shared/rateLimit.mjs', () => ({
 
 vi.mock('../../netlify/shared/logger.mjs');
 
-import {apiHandler, validateBody, validateOrigin} from '../../netlify/shared/middleware.mjs';
+import {apiHandler, validateBody, validateOrigin, requestEndpoint} from '../../netlify/shared/middleware.mjs';
 import {sendNotificationEmail} from '../../netlify/shared/giverNotification.mjs';
 import {checkRateLimit} from '../../netlify/shared/rateLimit.mjs';
 import {logger} from '../../netlify/shared/logger.mjs';
@@ -72,6 +72,12 @@ describe("apiHandler", () => {
         expect(result.statusCode).toBe(500);
     });
 
+});
+
+describe("requestEndpoint", () => {
+    it("combines httpMethod and path", () => {
+        expect(requestEndpoint({httpMethod: "POST", path: "/api/test"})).toBe("POST /api/test");
+    });
 });
 
 describe("validateOrigin", () => {

--- a/spec/netlify-functions/requireAuth.spec.js
+++ b/spec/netlify-functions/requireAuth.spec.js
@@ -1,6 +1,8 @@
-import {describe, it, expect, beforeAll, afterAll, afterEach} from "vitest";
+import {describe, it, expect, beforeAll, afterAll, afterEach, vi} from "vitest";
 import {setupMongo, teardownMongo, cleanCollections} from '../shared/mongoSetup.js';
 import {makeUser, seedUsers} from '../shared/testData.js';
+
+vi.mock("../../netlify/shared/logger.mjs");
 
 describe("requireAuth", () => {
     let mongo, db, requireAuth, signSession;

--- a/spec/netlify-functions/schemas/settings.spec.js
+++ b/spec/netlify-functions/schemas/settings.spec.js
@@ -1,0 +1,19 @@
+import {describe, it, expect} from "vitest";
+import {settingsSchema} from "../../../netlify/shared/schemas/settings.mjs";
+
+describe("settingsSchema", () => {
+    it("accepts a valid settings document", () => {
+        const result = settingsSchema.safeParse({_id: "global", logLevel: "warn"});
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects an invalid logLevel", () => {
+        const result = settingsSchema.safeParse({_id: "global", logLevel: "verbose"});
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects an _id other than 'global'", () => {
+        const result = settingsSchema.safeParse({_id: "other", logLevel: "warn"});
+        expect(result.success).toBe(false);
+    });
+});

--- a/spec/netlify-functions/settings.spec.js
+++ b/spec/netlify-functions/settings.spec.js
@@ -1,0 +1,59 @@
+import {describe, it, expect, beforeAll, afterAll, afterEach, vi} from "vitest";
+import {setupMongo, teardownMongo, cleanCollections} from '../shared/mongoSetup.js';
+
+describe("settings", () => {
+    let db, mongo, getLogLevel, setLogLevel, _resetLogLevelCache;
+
+    beforeAll(async () => {
+        mongo = await setupMongo();
+        ({db} = mongo);
+        const mod = await import("../../netlify/shared/settings.mjs");
+        getLogLevel = mod.getLogLevel;
+        setLogLevel = mod.setLogLevel;
+        _resetLogLevelCache = mod._resetLogLevelCache;
+    });
+
+    afterEach(async () => {
+        _resetLogLevelCache();
+        await cleanCollections(db, "settings");
+    });
+
+    afterAll(async () => {
+        await teardownMongo(mongo);
+    });
+
+    it("defaults to warn when no settings document exists", async () => {
+        expect(await getLogLevel()).toBe("warn");
+    });
+
+    it("returns the stored level after setLogLevel", async () => {
+        await setLogLevel("error");
+        expect(await getLogLevel()).toBe("error");
+    });
+
+    it("persists the level to the settings collection", async () => {
+        await setLogLevel("debug");
+        const doc = await db.collection("settings").findOne({_id: "global"});
+        expect(doc.logLevel).toBe("debug");
+    });
+
+    it("caches the level for subsequent reads instead of hitting the db every time", async () => {
+        await setLogLevel("error");
+        await db.collection("settings").updateOne({_id: "global"}, {$set: {logLevel: "debug"}});
+        expect(await getLogLevel()).toBe("error");
+    });
+
+    it("clears the cache when setLogLevel is called", async () => {
+        await setLogLevel("error");
+        await getLogLevel();
+        await setLogLevel("debug");
+        expect(await getLogLevel()).toBe("debug");
+    });
+
+    it("fails open to debug when the settings lookup throws", async () => {
+        const dbMod = await import("../../netlify/shared/db.mjs");
+        const spy = vi.spyOn(dbMod, "getSettingsCollection").mockRejectedValueOnce(new Error("DB down"));
+        expect(await getLogLevel()).toBe("debug");
+        spy.mockRestore();
+    });
+});

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -4,6 +4,7 @@ import * as snackbar from '../Snackbar.js';
 import {loadSession} from '../session.js';
 import {renderFilters, getFilterValues, populateEndpoints} from './logFilters.js';
 import {renderTable} from './logTable.js';
+import {renderLogLevelControl} from './logLevelControl.js';
 import {selectElement, addEventListener} from '../utils.js';
 
 function adminLayout() {
@@ -11,6 +12,7 @@ function adminLayout() {
         <header class="admin-header">
             <h1>Admin Logs</h1>
             <span class="admin-header-badge">Admin</span>
+            <div id="log-level-container"></div>
         </header>
         <main class="admin-main">
             <div id="filters-container"></div>
@@ -45,6 +47,7 @@ async function loadLogs() {
 function initDashboard() {
     const content = selectElement('#admin-content');
     content.innerHTML = adminLayout();
+    renderLogLevelControl(selectElement('#log-level-container'));
     renderFilters(selectElement('#filters-container'), loadLogs);
     loadLogs();
 }

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -12,10 +12,12 @@ function adminLayout() {
         <header class="admin-header">
             <h1>Admin Logs</h1>
             <span class="admin-header-badge">Admin</span>
-            <div id="log-level-container"></div>
         </header>
         <main class="admin-main">
-            <div id="filters-container"></div>
+            <div class="admin-toolbar">
+                <div id="filters-container"></div>
+                <div id="log-level-container"></div>
+            </div>
             <div id="logs-container"></div>
         </main>`;
 }

--- a/src/admin/logFilters.js
+++ b/src/admin/logFilters.js
@@ -8,35 +8,39 @@ export function renderFilters(container, onSearch) {
     onSearchFn = onSearch;
     container.innerHTML = `
         <div class="admin-filters">
-            <div class="admin-filter-group">
-                <label for="filter-level">Level</label>
-                <select id="filter-level">
-                    <option value="">All levels</option>
-                    <option value="info">Info</option>
-                    <option value="warn">Warn</option>
-                    <option value="error">Error</option>
-                    <option value="debug">Debug</option>
-                </select>
+            <div class="admin-filter-row">
+                <div class="admin-filter-group">
+                    <label for="filter-level">Level</label>
+                    <select id="filter-level">
+                        <option value="">All levels</option>
+                        <option value="info">Info</option>
+                        <option value="warn">Warn</option>
+                        <option value="error">Error</option>
+                        <option value="debug">Debug</option>
+                    </select>
+                </div>
+                <div class="admin-filter-group">
+                    <label for="filter-endpoint">Endpoint</label>
+                    <select id="filter-endpoint"><option value="">All endpoints</option></select>
+                </div>
+                <div class="admin-filter-group admin-filter-grow">
+                    <label for="filter-message">Message</label>
+                    <input type="text" id="filter-message" placeholder="Search message...">
+                </div>
             </div>
-            <div class="admin-filter-group">
-                <label for="filter-endpoint">Endpoint</label>
-                <select id="filter-endpoint"><option value="">All endpoints</option></select>
-            </div>
-            <div class="admin-filter-group">
-                <label for="filter-message">Message</label>
-                <input type="text" id="filter-message" placeholder="Search message...">
-            </div>
-            <div class="admin-filter-group">
-                <label for="filter-from">From</label>
-                <input type="datetime-local" id="filter-from">
-            </div>
-            <div class="admin-filter-group">
-                <label for="filter-to">To</label>
-                <input type="datetime-local" id="filter-to">
-            </div>
-            <div class="admin-filter-group admin-filter-action">
-                <span aria-hidden="true"></span>
-                <button id="filter-search" class="admin-btn admin-btn-inline">Search</button>
+            <div class="admin-filter-row">
+                <div class="admin-filter-group">
+                    <label for="filter-from">From</label>
+                    <input type="datetime-local" id="filter-from">
+                </div>
+                <div class="admin-filter-group">
+                    <label for="filter-to">To</label>
+                    <input type="datetime-local" id="filter-to">
+                </div>
+                <div class="admin-filter-group admin-filter-action">
+                    <span aria-hidden="true"></span>
+                    <button id="filter-search" class="admin-btn admin-btn-inline">Search</button>
+                </div>
             </div>
         </div>`;
     addEventListener('#filter-level', 'change', () => {

--- a/src/admin/logLevelControl.js
+++ b/src/admin/logLevelControl.js
@@ -1,0 +1,45 @@
+import {selectElement, addEventListener} from '../utils.js';
+import * as snackbar from '../Snackbar.js';
+
+export function renderLogLevelControl(container) {
+    container.innerHTML = `
+        <div class="admin-filters admin-log-level">
+            <div class="admin-filter-group">
+                <label for="log-level-select">Log level</label>
+                <select id="log-level-select">
+                    <option value="debug">Debug</option>
+                    <option value="info">Info</option>
+                    <option value="warn">Warn</option>
+                    <option value="error">Error</option>
+                </select>
+            </div>
+            <div class="admin-filter-group admin-filter-action">
+                <span aria-hidden="true"></span>
+                <button id="log-level-save" class="admin-btn admin-btn-inline">Save</button>
+            </div>
+        </div>`;
+
+    addEventListener('#log-level-save', 'click', saveLogLevel);
+    loadLogLevel();
+}
+
+async function loadLogLevel() {
+    const res = await fetch('/.netlify/functions/api-admin-settings-get');
+    if (!res.ok) return;
+    const {logLevel} = await res.json();
+    selectElement('#log-level-select').value = logLevel;
+}
+
+async function saveLogLevel() {
+    const logLevel = selectElement('#log-level-select').value;
+    const res = await fetch('/.netlify/functions/api-admin-settings-put', {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({logLevel}),
+    });
+    if (!res.ok) {
+        snackbar.showError('Failed to update log level');
+        return;
+    }
+    snackbar.showSuccess('Log level updated');
+}

--- a/src/admin/logLevelControl.js
+++ b/src/admin/logLevelControl.js
@@ -4,18 +4,20 @@ import * as snackbar from '../Snackbar.js';
 export function renderLogLevelControl(container) {
     container.innerHTML = `
         <div class="admin-filters admin-log-level">
-            <div class="admin-filter-group">
-                <label for="log-level-select">Log level</label>
-                <select id="log-level-select">
-                    <option value="debug">Debug</option>
-                    <option value="info">Info</option>
-                    <option value="warn">Warn</option>
-                    <option value="error">Error</option>
-                </select>
-            </div>
-            <div class="admin-filter-group admin-filter-action">
-                <span aria-hidden="true"></span>
-                <button id="log-level-save" class="admin-btn admin-btn-inline">Save</button>
+            <div class="admin-filter-row">
+                <div class="admin-filter-group">
+                    <label for="log-level-select">Log level</label>
+                    <select id="log-level-select">
+                        <option value="debug">Debug</option>
+                        <option value="info">Info</option>
+                        <option value="warn">Warn</option>
+                        <option value="error">Error</option>
+                    </select>
+                </div>
+                <div class="admin-filter-group admin-filter-action">
+                    <span aria-hidden="true"></span>
+                    <button id="log-level-save" class="admin-btn admin-btn-inline">Save</button>
+                </div>
             </div>
         </div>`;
 

--- a/src/admin/logTable.js
+++ b/src/admin/logTable.js
@@ -30,7 +30,7 @@ function buildRows(logs) {
     }).join('');
 }
 
-export function renderTable({logs, total, page, pages}, onPageChange) {
+export function renderTable({logs, total, page, pages, range}, onPageChange) {
     const container = selectElement('#logs-container');
 
     if (!logs.length) {
@@ -38,8 +38,10 @@ export function renderTable({logs, total, page, pages}, onPageChange) {
         return;
     }
 
+    const rangeText = range ? ` · ${new Date(range.from).toLocaleString()} – ${new Date(range.to).toLocaleString()}` : '';
+
     container.innerHTML = `
-        <p class="admin-table-summary">Showing ${logs.length} of ${total} logs</p>
+        <p class="admin-table-summary">Showing ${logs.length} of ${total} logs${rangeText}</p>
         <div class="admin-table-wrap">
             <table class="admin-table">
                 <thead>


### PR DESCRIPTION
## Summary
- Admin logs panel now shows the active date-range it's querying inline in the results summary, instead of silently defaulting to the last 24h with no indication.
- Log level is now runtime-configurable from the admin panel (new `settings` Mongo collection, cached read/write module, logger threshold enforcement, two new admin-only endpoints, and a UI control). Defaults to `warn`.
- Fixed a bug where the `endpoint` field logged with every request was inconsistently formatted (`"METHOD /path"` vs bare `"/path"`) across ~16 call sites, causing duplicate-looking entries in the admin panel's endpoint filter dropdown. Standardized via a shared `requestEndpoint()` helper; also removed one log line that carried zero information beyond the framework's own per-request log.

Full design spec and implementation plan: `docs/superpowers/specs/2026-07-16-admin-logs-range-loglevel-design.md` / `docs/superpowers/plans/2026-07-16-admin-logs-range-loglevel.md` (local only — `docs/` is gitignored in this repo).

## Test plan
- [x] Full suite passing: 88 files, 930 tests, 0 failures
- [x] Each of the 11 implementation tasks reviewed individually for spec compliance + code quality
- [x] Final whole-branch review completed — no Critical or Important issues
- [ ] **Manual browser verification still needed before deploy** (log-level dropdown loads/saves/persists across reload, date range renders in table summary) — could not be completed in this environment since it requires the admin email-auth flow to receive a real verification code

## Behavior change to be aware of
Default log level `warn` means the admin logs panel will show noticeably less by default than before this PR (no more info/debug noise, including the per-request `[API] ...` line). Set the level to `info`/`debug` from the new admin control when you need request-level visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)